### PR TITLE
不完全なADTSしか含まれていないPESがあるときデュアルモノ分離とステレオ化が正常に動作しなくなる問題を修正

### DIFF
--- a/servicefilter.cpp
+++ b/servicefilter.cpp
@@ -950,10 +950,14 @@ bool CServiceFilter::TransmuxDualMono(const std::vector<uint8_t> &unitPackets)
                 m_buf.resize(6 + pesPacketLength);
                 if (Aac::TransmuxDualMono(m_destLeftBuf, m_destRightBuf, m_audio1MuxDualMonoWorkspace,
                                           m_audio1MuxToStereo, m_audio2MuxToStereo,
-                                          m_buf.data() + pesPayloadPos, m_buf.size() - pesPayloadPos) &&
-                    !m_destLeftBuf.empty() &&
-                    !m_destRightBuf.empty()) {
+                                          m_buf.data() + pesPayloadPos, m_buf.size() - pesPayloadPos)) {
 
+                    if (m_destLeftBuf.empty() || m_destRightBuf.empty()) {
+                        if (m_destLeftBuf.empty() && m_destRightBuf.empty()) {
+                            return true;
+                        }
+                        return false;
+                    }
                     // Dual mono left
                     m_buf.resize(pesPayloadPos);
                     m_buf.insert(m_buf.end(), m_destLeftBuf.begin(), m_destLeftBuf.end());

--- a/servicefilter.cpp
+++ b/servicefilter.cpp
@@ -913,9 +913,11 @@ bool CServiceFilter::TransmuxMonoToStereo(const std::vector<uint8_t> &unitPacket
             size_t pesPayloadPos = 9 + m_buf[8];
             if (pesPayloadPos < 6 + pesPacketLength) {
                 m_buf.resize(6 + pesPacketLength);
-                if (Aac::TransmuxMonoToStereo(m_destLeftBuf, workspace, m_buf.data() + pesPayloadPos, m_buf.size() - pesPayloadPos) &&
-                    !m_destLeftBuf.empty()) {
+                if (Aac::TransmuxMonoToStereo(m_destLeftBuf, workspace, m_buf.data() + pesPayloadPos, m_buf.size() - pesPayloadPos)) {
 
+                    if (m_destLeftBuf.empty()) {
+                        return true;
+                    }
                     // Stereo
                     m_buf.resize(pesPayloadPos);
                     m_buf.insert(m_buf.end(), m_destLeftBuf.begin(), m_destLeftBuf.end());


### PR DESCRIPTION
下記に示すPES#2のように不完全なADTSのみが含まれている場合このPESを処理した時点ではAac::TransmuxDualMonoは何も出力せず、その場合CServiceFilter::TransmuxDualMonoはfalseを返してしまい、PESがパススルー出力されて音声のデコードに部分的に失敗する問題が存在していました。
また、モノラル音声のステレオ化でも同様の問題があったため修正しています。
```
|PES#1       |PES#2 |PES#3       |
|ADTS#1ADTS#2|ADTS#2|ADTS#2ADTS#3|
             ^^^^^^^^
```

PESに含まれるADTSが7バイト未満でかつデュアルモノ/モノラルでない場合に正常にパススルーされなくなる可能性がありますが、通常のTSではそのケースを踏む可能性は低いのでこのPRの修正には含んでいません。
https://github.com/xtne6f/tsreadex/blob/eddc8bca0de99627d3867259e7a6e777cbd3b3c6/aac.cpp#L505-L507
https://github.com/xtne6f/tsreadex/blob/eddc8bca0de99627d3867259e7a6e777cbd3b3c6/aac.cpp#L671-L673